### PR TITLE
[Context menu] Right-clicking page will use the current active tab url (closes #29)

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -64,9 +64,13 @@ function closePanel() {
 // Right-click -> "Open with Livestreamer"
 contextMenu.Item({
     label: locale("label"),
-    context: contextMenu.SelectorContext("a[href]"),
-    contentScript: 'self.on("click", function(node, data){' +
-                   '    self.postMessage(node.href);' +
+    context: contextMenu.SelectorContext("a[href], body"),
+    contentScript: 'self.on("click", function(node, data) {' +
+                   '    var stream = node.href;' +
+                   '    if(!node.href) {' +
+                   '        stream = window.location.href;' +
+                   '    }' +
+                   '    self.postMessage(stream);' +
                    '});',
     onMessage: function(streamURL) {
         // Display quality menu?


### PR DESCRIPTION
I did not want the work being done on the svg loading icon, [which was not going anywhere](https://github.com/IsSuEat/open-livestreamer-firefox-addon/pull/30#issuecomment-118140543), to effect issue #29. I split the work and this PR is just for #29.

changelog:
* Context-menu change (closes #29)
    * Right-clicking page will use the current active tab url
    * Right-clicking a link will use the href's link