### PR TITLE
Update theme detection & allow override in settings

### DIFF
--- a/data/js/global.js
+++ b/data/js/global.js
@@ -49,7 +49,11 @@ function buildQuality(payload) {
         self.port.emit("resolution-selected", [url, e.target.name]);
     }
 }
+function changeTheme(theme) {
+    document.body.id = theme;
+}
 // Listen for
 self.port.on("status", updateStatus);
 self.port.on("loading", buildLoading);
 self.port.on("quality", buildQuality);
+self.port.on("theme", changeTheme)

--- a/lib/main.js
+++ b/lib/main.js
@@ -4,19 +4,16 @@ var { ToggleButton } = require("sdk/ui/button/toggle"),
     self             = require("sdk/self"),
     system           = require("sdk/system"),
     tabs             = require("sdk/tabs"),
+    sp               = require("sdk/simple-prefs"),
     prefs            = require("sdk/simple-prefs").prefs,
     contextMenu      = require("sdk/context-menu"),
     locale           = require("sdk/l10n").get,
     winUtils         = require("sdk/window/utils");
 
-var iconPath         = "./img/icon.svg",
+// Default theme
+var theme            = "light",
+    iconPath         = "./img/icon.svg",
     loadingPath      = self.data.load("./img/loading.svg");
-
-// Check if dark theme is present
-if(isDarkTheme()) {
-    var theme       = "dark";
-        iconPath    = "./img/icon.white.svg";
-}
 
 // The universal button for Open With Livestreamer
 var button = ToggleButton({
@@ -34,10 +31,17 @@ var panel = panels.Panel({
     height: 97,
     onHide: closePanel,
     contentScriptFile: self.data.url("./js/global.js"),
-    contentScript: 'document.body.id = "' + theme + '";',
     contentScriptOptions: {
         loadingPath: loadingPath,
     }
+});
+
+// Set the Default theme when the panel is loaded
+themeChange();
+
+// Watch for theme update if user changes settings in about:addons
+sp.on("theme", function() {
+    themeChange();
 });
 
 // Opens the panel and checks the button.
@@ -276,6 +280,23 @@ function isDarkTheme() {
     let maxColor                   = Math.max.apply(null, [colorText[1], colorText[2], colorText[3]]);
     let maxBG                      = Math.max.apply(null, [colorBG[1], colorBG[2], colorBG[3]]);
     return maxColor > maxBG;
+}
+
+// themeChange
+// Check if dark theme is present, else loads light theme.
+// Then changes the icon & background depending on the current theme.
+// @param  void
+// @return void
+function themeChange() {
+    if(isDarkTheme() && prefs.theme != "light" || prefs.theme == "dark") {
+        theme       = "dark";
+        iconPath    = "./img/icon.white.svg";
+    } else {
+        theme       = "light";
+        iconPath    = "./img/icon.svg";
+    }
+    button.icon = iconPath;
+    panel.port.emit("theme", theme);
 }
 
 // Usefull function to see if an item exist in an array

--- a/locale/en-US.properties
+++ b/locale/en-US.properties
@@ -21,3 +21,6 @@ optargs_description=You can pass livestreamer options here in the form of --foo=
 
 qualityselector_title=Quality selection menu
 qualityselector_description=Display a quality selection window everytime livestreamer is launched
+
+theme_title=Theme
+theme_description=Use the light or dark theme or let Open in Livestreamer detect it automatically (results may vary).

--- a/package.json
+++ b/package.json
@@ -34,5 +34,21 @@
         "description": "Display a quality selection window everytime livestreamer is launched. ",
         "type": "bool",
         "value": true
+    },{
+    	"name": "theme",
+    	"title": "Theme",
+    	"description": "Use the light or dark theme or let Open in Livestreamer detect it automatically (results may vary).",
+        "type": "menulist",
+        "value": "auto",
+	"options": [{
+		"value": "auto",
+		"label": "Auto"
+	}, {
+		"value": "light",
+		"label": "Light"
+	}, {
+		"value": "dark",
+		"label": "Dark"
+	}]
     }]
 }


### PR DESCRIPTION
changelog
* fix #43 (sorta, this can never be fixed as it depends on other people making themes but at least we have a workaround)
* Adds an option in about:addons to change the theme (auto/light/dark)
 * Updates the theme as soon as the option is changed
* Added new parameters in en-US.properties
 * `theme_title` & `theme_description`
 * German translation needs update

tested
* Linux/Debian (Iceweasel 38)
* Windows (Firefox 43.0.1)
