### PR TITLE
Added icon to context-menu (right click)

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -74,6 +74,7 @@ function closePanel() {
 // Right-click -> "Open with Livestreamer"
 contextMenu.Item({
     label: locale("label"),
+    image: self.data.url(iconPath),
     context: contextMenu.SelectorContext("a[href], body"),
     contentScript: 'self.on("click", function(node, data) {' +
                    '    var stream = node.href;' +


### PR DESCRIPTION
changelog
* Added Open in Livestreamer icon to context-menu (right click)

tested
* Windows (Firefox 43.0.1)

Unable to test on Linux because I have an outdated version of iceweasel and to lazy to compile the real firefox.