### PR TITLE
Adding twitch.tv authentication fix

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -212,6 +212,8 @@ function getLivestreamerValidation(url) {
         quality,
         qualityPattern = ['best', 'source', 'live', '2160p', '1440p', '1080p+', '1080p', 'ultra', 'high', '720p+', '720p', 'medium', 'mid', '480p+', '480p', 'low', '360p+', '360p', '240p', '144p', 'mobile', 'worst', 'audio'],
         results = [],
+        optArgs = [],
+        args,
         i;
     // Notify
     panel.width = 250;
@@ -226,8 +228,12 @@ function getLivestreamerValidation(url) {
     }
     // Create child instance
     process = require("sdk/system/child_process");
+    if (prefs.optargs) {
+        optArgs = prefs.optargs.split(",");
+    }
+    args = ["--json", url].concat(optArgs);
     // Spawn a seperate child to validate in Livestreamer
-    livestreamer = process.spawn(path, ["--json", url]);
+    livestreamer = process.spawn(path, args);
     // As the stream comes in, grab the data
     livestreamer.stdout.on('data', function(data) {
         // Notify


### PR DESCRIPTION
For some time Twitch API requires authentication token to be passed. This extension makes it possible by passing optional arguments to livestreamer (in this case it would be --twitch-oauth-token=<token>). But for some reason those optional arguments are not being passed during url validation which results in an authentication error. I present to you my solution to this problem. :smile:  
